### PR TITLE
Escape pipes in table

### DIFF
--- a/ghokin/fixtures/escape-pipe.feature
+++ b/ghokin/fixtures/escape-pipe.feature
@@ -1,0 +1,6 @@
+Feature: Test
+
+  Scenario: Pipe in table value
+    Given I have a table:
+      | a | b \| c | \| d | \| e \| |
+      | f | g      | h    | i       |

--- a/ghokin/transformer.go
+++ b/ghokin/transformer.go
@@ -253,7 +253,9 @@ func extractTableRows(tokens []*gherkin.Token) []string {
 		row := []string{}
 
 		for _, data := range tab.Items {
-			row = append(row, data.Text)
+			// A remaining pipe means it was escaped before to not be messed with pipe column delimiter
+			// so here we introduce the escaping sequence back
+			row = append(row, strings.ReplaceAll(data.Text, "|", "\\|"))
 		}
 
 		rows = append(rows, row)

--- a/ghokin/transformer_test.go
+++ b/ghokin/transformer_test.go
@@ -432,6 +432,10 @@ func TestTransform(t *testing.T) {
 			"fixtures/comment-after-background.feature",
 			"fixtures/comment-after-background.feature",
 		},
+		{
+			"fixtures/escape-pipe.feature",
+			"fixtures/escape-pipe.feature",
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
When a pipe was escaped in a table column, it was not escaped back when the output was formatted.

Fix #50 
