### PR TITLE
Fix an issue when escaping new line

### DIFF
--- a/ghokin/fixtures/escape-new-line.feature
+++ b/ghokin/fixtures/escape-new-line.feature
@@ -1,0 +1,6 @@
+Feature: Test
+
+  Scenario: Newline in table value
+    Given I have a table:
+      | a | b \n c | \n d | \n e \n |
+      | f | g      | h    | i       |

--- a/ghokin/transformer.go
+++ b/ghokin/transformer.go
@@ -217,7 +217,10 @@ func extractTableRows(tokens []*gherkin.Token) []string {
 		for _, data := range tab.Items {
 			// A remaining pipe means it was escaped before to not be messed with pipe column delimiter
 			// so here we introduce the escaping sequence back
-			row = append(row, strings.ReplaceAll(data.Text, "|", "\\|"))
+			text := data.Text
+			text = strings.ReplaceAll(text, "|", "\\|")
+			text = strings.ReplaceAll(text, "\n", "\\n")
+			row = append(row, text)
 		}
 
 		rows = append(rows, row)

--- a/ghokin/transformer_test.go
+++ b/ghokin/transformer_test.go
@@ -437,6 +437,10 @@ func TestTransform(t *testing.T) {
 			"fixtures/escape-pipe.feature",
 		},
 		{
+			"fixtures/escape-new-line.feature",
+			"fixtures/escape-new-line.feature",
+		},
+		{
 			"fixtures/several-scenario-following.feature",
 			"fixtures/several-scenario-following.feature",
 		},


### PR DESCRIPTION
Fix #97, new line character is not properly escaped and replaced by a new
line in tables