### PR TITLE
Fix formatting issue with special characters

### DIFF
--- a/ghokin/fixtures/non-ascii-characters-formatting.feature
+++ b/ghokin/fixtures/non-ascii-characters-formatting.feature
@@ -1,0 +1,5 @@
+Feature: Test
+
+  Scenario: This is a scenario
+    Given I have a table:
+      | äöüûú |

--- a/ghokin/transformer.go
+++ b/ghokin/transformer.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cucumber/common/gherkin/go/v23"
 )
@@ -244,9 +245,9 @@ func calculateLonguestLineLengthPerColumn(rows [][]string) []int {
 		for j, str := range row {
 			switch true {
 			case i == 0:
-				lengths = append(lengths, len(str))
-			case i != 0 && len(lengths) > j && lengths[j] < len(str):
-				lengths[j] = len(str)
+				lengths = append(lengths, utf8.RuneCountInString(str))
+			case i != 0 && len(lengths) > j && lengths[j] < utf8.RuneCountInString(str):
+				lengths[j] = utf8.RuneCountInString(str)
 			default:
 				lengths = append(lengths, 0)
 			}

--- a/ghokin/transformer_test.go
+++ b/ghokin/transformer_test.go
@@ -444,6 +444,10 @@ func TestTransform(t *testing.T) {
 			"fixtures/rule.feature",
 			"fixtures/rule.feature",
 		},
+		{
+			"fixtures/non-ascii-characters-formatting.feature",
+			"fixtures/non-ascii-characters-formatting.feature",
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
Fix #98, length of special characters is not properly calculated, the number of
byte is calculated instead of the number of characters, use the
utf8.RuneCountInString instead of len