### PR TITLE
Fix table formatting

### DIFF
--- a/ghokin/fixtures/comment-in-a-midst-of-row.feature
+++ b/ghokin/fixtures/comment-in-a-midst-of-row.feature
@@ -1,0 +1,21 @@
+Feature: Test Formatter
+  Scenario: Comment between rows
+    Given table my_table
+      | col a | col b |
+      | 1     | 2     |
+      # A comment about the row below
+      | 3     | 4     |
+      # Another comment about the row below
+      | 5     | 6     |
+      | 7     | 8     |
+      | 9     | 10    |
+    Given table my_table
+      | col a | col b |
+      | 1     | 2     |
+      # A comment about the row below
+      | 3     | 4     |
+      # Another comment about the row below
+      | 5     | 6     |
+    Given a second thing
+    Given another second thing
+    Then another thing happened

--- a/ghokin/transformer_test.go
+++ b/ghokin/transformer_test.go
@@ -127,7 +127,7 @@ func TestExtractTableRows(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		scenario.test(extractTableRows(scenario.tokens))
+		scenario.test(extractTableRowsAndComments(scenario.tokens))
 	}
 }
 
@@ -454,6 +454,10 @@ func TestTransform(t *testing.T) {
 		{
 			"fixtures/double-escaping.feature",
 			"fixtures/double-escaping.feature",
+		},
+		{
+			"fixtures/comment-in-a-midst-of-row.feature",
+			"fixtures/comment-in-a-midst-of-row.feature",
 		},
 	}
 


### PR DESCRIPTION
When a comment is inserted in the midst of a table, the rest of the table is unproperly formatted.

Fix #128 