### PR TITLE
Scenario description indent

### DIFF
--- a/ghokin/fixtures/scenario-description.feature
+++ b/ghokin/fixtures/scenario-description.feature
@@ -1,0 +1,13 @@
+Feature: A feature
+
+  Scenario: First line
+  Second line
+
+    Given a thing
+
+  Scenario:
+  """
+  Triple quotes first line
+  Triple quotes second line
+  """
+    Given a thing

--- a/ghokin/fixtures/scenario-description.feature
+++ b/ghokin/fixtures/scenario-description.feature
@@ -1,13 +1,18 @@
 Feature: A feature
 
-  Scenario: First line
-  Second line
+  Scenario: Scenario name
+  Second description
 
     Given a thing
 
-  Scenario:
+  Scenario: Scenario name
   """
   Triple quotes first line
   Triple quotes second line
   """
     Given a thing
+
+  Rule: A rule
+    Scenario: Scenario name
+    Rule scenario description
+      Given a thing

--- a/ghokin/fixtures/scenario-description.feature
+++ b/ghokin/fixtures/scenario-description.feature
@@ -1,7 +1,7 @@
 Feature: A feature
 
   Scenario: Scenario name
-  Second description
+  Scenario description
 
     Given a thing
 

--- a/ghokin/fixtures/scenario-description.feature
+++ b/ghokin/fixtures/scenario-description.feature
@@ -2,7 +2,6 @@ Feature: A feature
 
   Scenario: Scenario name
   Scenario description
-
     Given a thing
 
   Scenario: Scenario name

--- a/ghokin/transformer.go
+++ b/ghokin/transformer.go
@@ -108,7 +108,7 @@ func transform(section *section, indent int, aliases aliases) ([]byte, error) {
 				padding = indent
 			} else if isDescriptionScenario(sec) {
 				lines = trimLinesSpace(lines)
-				padding = paddings[gherkin.TokenTypeScenarioLine]
+				padding = paddings[gherkin.TokenTypeScenarioLine] + optionalRulePadding
 			}
 		}
 

--- a/ghokin/transformer.go
+++ b/ghokin/transformer.go
@@ -106,6 +106,9 @@ func transform(section *section, indent int, aliases aliases) ([]byte, error) {
 			if isDescriptionFeature(sec) {
 				lines = trimLinesSpace(lines)
 				padding = indent
+			} else if isDescriptionScenario(sec) {
+				lines = trimLinesSpace(lines)
+				padding = paddings[gherkin.TokenTypeScenarioLine]
 			}
 		}
 
@@ -156,6 +159,16 @@ func isDescriptionFeature(sec *section) bool {
 	excluded := []gherkin.TokenType{gherkin.TokenTypeEmpty}
 	if sec.previous(excluded) != nil {
 		if s := sec.previous(excluded); s != nil && s.kind == gherkin.TokenTypeFeatureLine {
+			return true
+		}
+	}
+	return false
+}
+
+func isDescriptionScenario(sec *section) bool {
+	excluded := []gherkin.TokenType{gherkin.TokenTypeEmpty}
+	if sec.previous(excluded) != nil {
+		if s := sec.previous(excluded); s != nil && s.kind == gherkin.TokenTypeScenarioLine {
 			return true
 		}
 	}

--- a/ghokin/transformer_test.go
+++ b/ghokin/transformer_test.go
@@ -459,6 +459,10 @@ func TestTransform(t *testing.T) {
 			"fixtures/comment-in-a-midst-of-row.feature",
 			"fixtures/comment-in-a-midst-of-row.feature",
 		},
+		{
+			"fixtures/scenario-description.feature",
+			"fixtures/scenario-description.feature",
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
Added support of scenario [description](https://cucumber.io/docs/gherkin/reference/#descriptions)([issue](https://github.com/cucumber/cucumber-jvm/issues/1605) in cucumber)

In the current implementation, a description moves right at each run of format. Due to this, each run of `ghokin check` returns a false result.
Now, a scenario description has indent the same as a scenario.
E.g. each run of format will produce the next result
```feature
Feature: A feature

  Scenario: Scenario name
  Scenario description
    Given a thing

  Scenario: Scenario name
  """
  Triple quotes first line
  Triple quotes second line
  """
    Given a thing

  Rule: A rule
    Scenario: Scenario name
    Rule scenario description
      Given a thing
```
fixes https://github.com/antham/ghokin/issues/152