### PR TITLE
feat: don't include stderr from external commands

### DIFF
--- a/ghokin/fixtures/stderr.expected.feature
+++ b/ghokin/fixtures/stderr.expected.feature
@@ -1,0 +1,9 @@
+Feature: A Feature
+  Description
+
+  Scenario: A scenario to test
+    Given a thing
+      # @stderr
+      """
+      text piped to stdin
+      """

--- a/ghokin/fixtures/stderr.input.feature
+++ b/ghokin/fixtures/stderr.input.feature
@@ -1,0 +1,9 @@
+Feature: A Feature
+  Description
+
+  Scenario: A scenario to test
+    Given a thing
+      # @stderr
+      """
+      text piped to stdin
+      """

--- a/ghokin/transformer.go
+++ b/ghokin/transformer.go
@@ -334,8 +334,9 @@ func runCommand(cmd *exec.Cmd, lines []string) ([]string, error) {
 		return lines, nil
 	}
 
+	cmd.Stderr = os.Stderr // output stderr to the console
 	cmd.Stdin = strings.NewReader(strings.Join(lines, "\n"))
-	o, err := cmd.CombinedOutput()
+	o, err := cmd.Output()
 	if err != nil {
 		return []string{}, CmdErr{strings.TrimRight(string(o), "\n")}
 	}

--- a/ghokin/transformer_test.go
+++ b/ghokin/transformer_test.go
@@ -416,6 +416,10 @@ func TestTransform(t *testing.T) {
 			"fixtures/cmd.expected.feature",
 		},
 		{
+			"fixtures/stderr.input.feature",
+			"fixtures/stderr.expected.feature",
+		},
+		{
 			"fixtures/multisize-table.input.feature",
 			"fixtures/multisize-table.expected.feature",
 		},
@@ -479,7 +483,8 @@ func TestTransform(t *testing.T) {
 			assert.NoError(t, err)
 
 			aliases := map[string]string{
-				"seq": "seq 1 3",
+				"seq":    "seq 1 3",
+				"stderr": `bash -c 'echo "this goes straight to stderr" >&2; cat'`,
 			}
 
 			buf, err := transform(s, 2, aliases)


### PR DESCRIPTION
Hi, one of the formatters i use prints logs to stderr, which are included in the formatted output of docstrings.

This pr just redirects the stderr of the subprocess to the main processes stderr and only captures the stdout.

This should not break existing setups, as most tools should print to stdout.